### PR TITLE
Make sure the service_principal parameters are transformed by jinja

### DIFF
--- a/tasks/parameter/sp.yml
+++ b/tasks/parameter/sp.yml
@@ -1,18 +1,18 @@
-- name: Load service_principal in ansible auth parameter
+- name: Load service_principal from ansible auth parameter
   set_fact:
       service_principal: "{{ client_id }}"
       client_secret: "{{ secret }}"
   when: service_principal is not defined
   ignore_errors: yes
 
-- name: Load service_princial in environment variables
+- name: Load service_principal from environment variables
   set_fact:
       service_principal: "{{ lookup('env', 'AZURE_CLIENT_ID') }}"
       client_secret: "{{ lookup('env', 'AZURE_SECRET') }}"
   when: service_principal is not defined
   ignore_errors: yes
 
-- name: Load service_princial in ~/.azure/credentials
+- name: Load service_princial from ~/.azure/credentials
   set_fact:
       service_principal: "{{ lookup('ini', 'client_id section=default file=~/.azure/credentials') }}"
       client_secret: "{{ lookup('ini', 'secret section=default file=~/.azure/credentials') }}"
@@ -21,8 +21,8 @@
 
 - name: Set service principal parameter
   set_fact:
-      sp: "{{ sp | default({}) | combine({ item.key: vars[item.value] }) }}"
+      sp: "{{ sp | default({}) | combine({ item.key: lookup('vars', item.value) }) }}"
   with_items:
       - {'key': 'client_id', 'value': 'service_principal' }
       - {'key': 'client_secret', 'value': 'client_secret' }
-  when: service_principal is defined and {{ item.value }} is defined
+  when: service_principal is defined and vars[item.value] is defined


### PR DESCRIPTION
`vars` passed to ansible.aks are not tranformed prior to passing to `azure_rm`.

For example:
```yaml
vars:
  app_id: "myid"

include_role:
  name: ansible.aks
vars:
    service_principal: "{{ app_id }}"
```

Using `-vvv` I can see the `client_id` is passed to `azure_rm` as `{{ app_id }}` and not `myid` as I would expect.

I've only included changes for sp in this PR so far. If you are happy with the changes I'll update the other parameter files which are affected in the same way.